### PR TITLE
Updated the Jackson Json package name

### DIFF
--- a/sample/pubsub/app/controllers/PubSub.java
+++ b/sample/pubsub/app/controllers/PubSub.java
@@ -1,6 +1,6 @@
 package controllers;
 
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.core.JsonNode;
 
 import play.libs.Json;
 


### PR DESCRIPTION
The package name has changed as documenented in [0]

> We have upgraded Jackson to version 2 which means 
> that the package name is now com.fasterxml.jackson.core
> instead of org.codehaus.jackson.

[0] http://www.playframework.com/documentation/2.2.0/Migration22
